### PR TITLE
convert tabs to spaces in all python files

### DIFF
--- a/exact/admin.py
+++ b/exact/admin.py
@@ -8,26 +8,26 @@ from .models import Session, Webhook
 
 
 class SessionAdmin(admin.ModelAdmin):
-	model = Session
-	list_display = ["id", "api_url", "redirect_uri", "client_id"]
+    model = Session
+    list_display = ["id", "api_url", "redirect_uri", "client_id"]
 admin.site.register(Session, SessionAdmin)
 
 
 # TODO: maybe use a better validation than just failing in pre_save/post_delete :)
 class WebhookAdminForm(forms.ModelForm):
-	class Meta:
-		model = Webhook
-		exclude = []
+    class Meta:
+        model = Webhook
+        exclude = []
 
-	def clean(self):
-		if not self.changed_data:
-			return
+    def clean(self):
+        if not self.changed_data:
+            return
 
-		#api = ExactApi()
+        #api = ExactApi()
 
 
 class WebhookAdmin(admin.ModelAdmin):
-	model = Webhook
-	# form = WebhookAdminForm
-	list_display = ["topic", "callback"]
+    model = Webhook
+    # form = WebhookAdminForm
+    list_display = ["topic", "callback"]
 admin.site.register(Webhook, WebhookAdmin)

--- a/exact/api.py
+++ b/exact/api.py
@@ -17,294 +17,294 @@ logger = logging.getLogger("exact")
 
 
 def _get(option):
-	try:
-		return getattr(settings, "EXACT_ONLINE_" + option)
-	except AttributeError:
-		raise ImproperlyConfigured("Exact: Setting '%s' not found!" % option)
+    try:
+        return getattr(settings, "EXACT_ONLINE_" + option)
+    except AttributeError:
+        raise ImproperlyConfigured("Exact: Setting '%s' not found!" % option)
 
 
 EXACT_SETTINGS = {
-	"redirect_uri": _get("REDIRECT_URI"),
-	"client_id": _get("CLIENT_ID"),
-	"client_secret": _get("CLIENT_SECRET"),
-	"api_url": _get("API_URL"),
-	"division": _get("DIVISION")
+    "redirect_uri": _get("REDIRECT_URI"),
+    "client_id": _get("CLIENT_ID"),
+    "client_secret": _get("CLIENT_SECRET"),
+    "api_url": _get("API_URL"),
+    "division": _get("DIVISION")
 }
 
 
 class ExactException(Exception):
-	def __init__(self, message, response):
-		super(ExactException, self).__init__(message)
-		self.response = response
+    def __init__(self, message, response):
+        super(ExactException, self).__init__(message)
+        self.response = response
 
 
 class DoesNotExist(Exception):
-	pass
+    pass
 
 
 class MultipleObjectsReturned(Exception):
-	pass
+    pass
 
 
 class Resource(object):
-	resource = ""
-	DoesNotExist = DoesNotExist
-	MultipleObjectsReturned = MultipleObjectsReturned
+    resource = ""
+    DoesNotExist = DoesNotExist
+    MultipleObjectsReturned = MultipleObjectsReturned
 
-	def __init__(self, api):
-		self._api = api
+    def __init__(self, api):
+        self._api = api
 
-	# i am not using *args, and **kwargs (would be more generic) to make autocomplete/hints in IDE work better
-	def filter(self, filter_string=None, select=None, order_by=None, limit=None):
-		return self._api.filter(self.resource, filter_string=filter_string, select=select, order_by=order_by, limit=limit)
+    # i am not using *args, and **kwargs (would be more generic) to make autocomplete/hints in IDE work better
+    def filter(self, filter_string=None, select=None, order_by=None, limit=None):
+        return self._api.filter(self.resource, filter_string=filter_string, select=select, order_by=order_by, limit=limit)
 
-	def get(self, filter_string=None, select=None):
-		return self._api.get(self.resource, filter_string=filter_string, select=select)
+    def get(self, filter_string=None, select=None):
+        return self._api.get(self.resource, filter_string=filter_string, select=select)
 
-	def create(self, data):
-		return self._api.create(self.resource, data)
+    def create(self, data):
+        return self._api.create(self.resource, data)
 
-	def update(self, guid, data):
-		return self._api.update(self.resource, guid, data)
+    def update(self, guid, data):
+        return self._api.update(self.resource, guid, data)
 
-	def delete(self, guid):
-		return self._api.delete(self.resource, guid)
+    def delete(self, guid):
+        return self._api.delete(self.resource, guid)
 
 
 # example of simplifying some resources
 class GetByCodeMixin(object):
-	def get(self, code=None, filter_string=None, select=None):
-		if code is not None:
-			if filter_string:
-				filter_string += " and Code eq '%s'" % code
-			else:
-				filter_string = "Code eq '%s'" % code
-		return super(GetByCodeMixin, self).get(filter_string=filter_string, select=select)
+    def get(self, code=None, filter_string=None, select=None):
+        if code is not None:
+            if filter_string:
+                filter_string += " and Code eq '%s'" % code
+            else:
+                filter_string = "Code eq '%s'" % code
+        return super(GetByCodeMixin, self).get(filter_string=filter_string, select=select)
 
 
 class Accounts(GetByCodeMixin, Resource):
-	resource = "crm/Accounts"
+    resource = "crm/Accounts"
 
-	def get(self, code=None, filter_string=None, select=None):
-		if code is not None:
-			code = "%18s" % code
-		return super(Accounts, self).get(code, filter_string, select)
+    def get(self, code=None, filter_string=None, select=None):
+        if code is not None:
+            code = "%18s" % code
+        return super(Accounts, self).get(code, filter_string, select)
 
 
 class Costcenters(GetByCodeMixin, Resource):
-	resource = "hrm/Costcenters"
+    resource = "hrm/Costcenters"
 
 
 class Costunits(GetByCodeMixin, Resource):
-	resource = "hrm/Costunits"
+    resource = "hrm/Costunits"
 
 
 class GLAccounts(GetByCodeMixin, Resource):
-	resource = "financial/GLAccounts"
+    resource = "financial/GLAccounts"
 
 
 class PurchaseEntries(Resource):
-	resource = "purchaseentry/PurchaseEntries"
+    resource = "purchaseentry/PurchaseEntries"
 
-	def get(self, entry_number=None, filter_string=None, select=None):
-		if entry_number is not None:
-			if filter_string:
-				filter_string += " and EntryNumber eq %d" % entry_number
-			else:
-				filter_string = "EntryNumber eq %d" % entry_number
-		return super(PurchaseEntries, self).get(filter_string, select)
+    def get(self, entry_number=None, filter_string=None, select=None):
+        if entry_number is not None:
+            if filter_string:
+                filter_string += " and EntryNumber eq %d" % entry_number
+            else:
+                filter_string = "EntryNumber eq %d" % entry_number
+        return super(PurchaseEntries, self).get(filter_string, select)
 
 
 class SalesEntries(PurchaseEntries):
-	resource = "salesentry/SalesEntries"
+    resource = "salesentry/SalesEntries"
 
 
 class Exact(object):
-	DoesNotExist = DoesNotExist
-	MultipleObjectsReturned = MultipleObjectsReturned
-	# this is only for benchmarking
-	# exact needs ~5.5 seconds to open a https connection
-	# so reusing it speeds things up a lot. (~200ms per call)
-	_REUSE_SESSION = True
+    DoesNotExist = DoesNotExist
+    MultipleObjectsReturned = MultipleObjectsReturned
+    # this is only for benchmarking
+    # exact needs ~5.5 seconds to open a https connection
+    # so reusing it speeds things up a lot. (~200ms per call)
+    _REUSE_SESSION = True
 
-	def __init__(self):
-		s, created = Session.objects.get_or_create(**EXACT_SETTINGS)
-		self.session = s
-		self.requests_session = ReqSession()
-		# set default headers for this session
-		self.requests_session.headers.update({
-			"Accept": "application/json",
-			"Authorization": "Bearer %s" % self.session.access_token,
-			"Content-Type": "application/json",
-			"Prefer": "return=representation",
-		})
+    def __init__(self):
+        s, created = Session.objects.get_or_create(**EXACT_SETTINGS)
+        self.session = s
+        self.requests_session = ReqSession()
+        # set default headers for this session
+        self.requests_session.headers.update({
+            "Accept": "application/json",
+            "Authorization": "Bearer %s" % self.session.access_token,
+            "Content-Type": "application/json",
+            "Prefer": "return=representation",
+        })
 
-		self.accounts = Accounts(self)
-		self.costcenters = Costcenters(self)
-		self.costunits = Costunits(self)
-		self.glaccounts = GLAccounts(self)
-		self.sales = PurchaseEntries(self)
-		self.purchases = PurchaseEntries(self)
+        self.accounts = Accounts(self)
+        self.costcenters = Costcenters(self)
+        self.costunits = Costunits(self)
+        self.glaccounts = GLAccounts(self)
+        self.sales = PurchaseEntries(self)
+        self.purchases = PurchaseEntries(self)
 
-	@property
-	def auth_url(self):
-		params = {
-			'client_id': self.session.client_id,
-			'redirect_uri': self.session.redirect_uri,
-			'response_type': 'code'
-		}
-		return self.session.api_url + "/oauth2/auth?" + urlencode(params)
+    @property
+    def auth_url(self):
+        params = {
+            'client_id': self.session.client_id,
+            'redirect_uri': self.session.redirect_uri,
+            'response_type': 'code'
+        }
+        return self.session.api_url + "/oauth2/auth?" + urlencode(params)
 
-	def _get_or_refresh_token(self, params):
-		req = Request("POST", self.session.api_url + "/oauth2/token", data=params)
-		prepped = self.requests_session.prepare_request(req)
-		# exact fails/returns 401 if we send an auth header here
-		del prepped.headers["Authorization"]
-		# this is also the only request which is not "application/json"
-		prepped.headers["Content-Type"] = "application/x-www-form-urlencoded"
+    def _get_or_refresh_token(self, params):
+        req = Request("POST", self.session.api_url + "/oauth2/token", data=params)
+        prepped = self.requests_session.prepare_request(req)
+        # exact fails/returns 401 if we send an auth header here
+        del prepped.headers["Authorization"]
+        # this is also the only request which is not "application/json"
+        prepped.headers["Content-Type"] = "application/x-www-form-urlencoded"
 
-		logger.debug("sending request: %s" % prepped.url)
-		response = self.requests_session.send(prepped)
-		if response.status_code != 200:
-			msg = "unexpected response while getting/refreshing token: %s" % response.text
-			raise ExactException(msg, response)
-		decoded = response.json()
-		self.session.access_token = decoded["access_token"]
-		self.session.refresh_token = decoded["refresh_token"]
-		# TODO: use access_expiry to avoid an unnecessary request if we know we will need to re-auth
-		self.session.access_expiry = int(time.time()) + int(decoded["expires_in"])
-		self.session.save()
-		# add new token to default headers
-		self.requests_session.headers["Authorization"] = "Bearer %s" % self.session.access_token
+        logger.debug("sending request: %s" % prepped.url)
+        response = self.requests_session.send(prepped)
+        if response.status_code != 200:
+            msg = "unexpected response while getting/refreshing token: %s" % response.text
+            raise ExactException(msg, response)
+        decoded = response.json()
+        self.session.access_token = decoded["access_token"]
+        self.session.refresh_token = decoded["refresh_token"]
+        # TODO: use access_expiry to avoid an unnecessary request if we know we will need to re-auth
+        self.session.access_expiry = int(time.time()) + int(decoded["expires_in"])
+        self.session.save()
+        # add new token to default headers
+        self.requests_session.headers["Authorization"] = "Bearer %s" % self.session.access_token
 
-	def get_token(self):
-		logger.debug("getting token")
-		params = {
-			"client_id": self.session.client_id,
-			"client_secret": self.session.client_secret,
-			"code": self.session.authorization_code,
-			"grant_type": 'authorization_code',
-			"redirect_uri": self.session.redirect_uri
-		}
-		self._get_or_refresh_token(params)
+    def get_token(self):
+        logger.debug("getting token")
+        params = {
+            "client_id": self.session.client_id,
+            "client_secret": self.session.client_secret,
+            "code": self.session.authorization_code,
+            "grant_type": 'authorization_code',
+            "redirect_uri": self.session.redirect_uri
+        }
+        self._get_or_refresh_token(params)
 
-	def refresh_token(self):
-		logger.debug("refreshing token")
-		params = {
-			'client_id': self.session.client_id,
-			'client_secret': self.session.client_secret,
-			'grant_type': 'refresh_token',
-			'refresh_token': self.session.refresh_token
-		}
-		self._get_or_refresh_token(params)
+    def refresh_token(self):
+        logger.debug("refreshing token")
+        params = {
+            'client_id': self.session.client_id,
+            'client_secret': self.session.client_secret,
+            'grant_type': 'refresh_token',
+            'refresh_token': self.session.refresh_token
+        }
+        self._get_or_refresh_token(params)
 
-	def _send(self, method, resource, data=None, params=None):
-		# to test performance penalty of not using a requests session
-		if not self._REUSE_SESSION:
-			self.requests_session = ReqSession()
-			self.requests_session.headers.update({
-				"Accept": "application/json",
-				"Authorization": "Bearer %s" % self.session.access_token,
-				"Content-Type": "application/json",
-				"Prefer": "return=representation",
-			})
+    def _send(self, method, resource, data=None, params=None):
+        # to test performance penalty of not using a requests session
+        if not self._REUSE_SESSION:
+            self.requests_session = ReqSession()
+            self.requests_session.headers.update({
+                "Accept": "application/json",
+                "Authorization": "Bearer %s" % self.session.access_token,
+                "Content-Type": "application/json",
+                "Prefer": "return=representation",
+            })
 
-		url = "%s/v1/%s/%s" % (self.session.api_url, self.session.division, resource)
-		request = Request(method, url, data=data, params=params)
-		prepped = self.requests_session.prepare_request(request)
+        url = "%s/v1/%s/%s" % (self.session.api_url, self.session.division, resource)
+        request = Request(method, url, data=data, params=params)
+        prepped = self.requests_session.prepare_request(request)
 
-		logger.debug("sending request: %s" % prepped.url)
-		response = self.requests_session.send(prepped)
-		if response.status_code == 401:
-			self.refresh_token()
-			# prepare again to use new auth-header
-			prepped = self.requests_session.prepare_request(request)
-			logger.debug("sending request: %s" % prepped.url)
-			response = self.requests_session.send(prepped)
+        logger.debug("sending request: %s" % prepped.url)
+        response = self.requests_session.send(prepped)
+        if response.status_code == 401:
+            self.refresh_token()
+            # prepare again to use new auth-header
+            prepped = self.requests_session.prepare_request(request)
+            logger.debug("sending request: %s" % prepped.url)
+            response = self.requests_session.send(prepped)
 
-		# at this point we tried to re-auth, so anything but 200/OK, 201/Created or 204/no content is unexpected
-		# yes: the exact documentation does not mention 204; returned on PUT anyways
-		if response.status_code not in (200, 201, 204):
-			msg = "Unexpected status code received. Expected one of (200, 201, 204), got %d\n\n%s"
-			msg %= (response.status_code, response.text)
-			logger.debug("%s\n%s" % (msg, response.text))
-			raise ExactException(msg, response)
+        # at this point we tried to re-auth, so anything but 200/OK, 201/Created or 204/no content is unexpected
+        # yes: the exact documentation does not mention 204; returned on PUT anyways
+        if response.status_code not in (200, 201, 204):
+            msg = "Unexpected status code received. Expected one of (200, 201, 204), got %d\n\n%s"
+            msg %= (response.status_code, response.text)
+            logger.debug("%s\n%s" % (msg, response.text))
+            raise ExactException(msg, response)
 
-		# don't try to decode json if we got nothing back
-		if response.status_code == 204:
-			return None
-		# TODO: handle the case where they send a 200, with HTML "we're under maintenance". yes, they do that
-		return response.json()
+        # don't try to decode json if we got nothing back
+        if response.status_code == 204:
+            return None
+        # TODO: handle the case where they send a 200, with HTML "we're under maintenance". yes, they do that
+        return response.json()
 
-	def raw(self, method, path, data=None, params=None, re_auth=True):
-		url = "%s%s" % (self.session.api_url, path)
-		request = Request(method, url, data=data, params=params)
-		prepped = self.requests_session.prepare_request(request)
+    def raw(self, method, path, data=None, params=None, re_auth=True):
+        url = "%s%s" % (self.session.api_url, path)
+        request = Request(method, url, data=data, params=params)
+        prepped = self.requests_session.prepare_request(request)
 
-		logger.debug("sending request: %s" % prepped.url)
-		response = self.requests_session.send(prepped)
-		if re_auth and response.status_code == 401:
-			self.refresh_token()
-			# prepare again to use new auth-header
-			prepped = self.requests_session.prepare_request(request)
-			logger.debug("sending request: %s" % prepped.url)
-			response = self.requests_session.send(prepped)
+        logger.debug("sending request: %s" % prepped.url)
+        response = self.requests_session.send(prepped)
+        if re_auth and response.status_code == 401:
+            self.refresh_token()
+            # prepare again to use new auth-header
+            prepped = self.requests_session.prepare_request(request)
+            logger.debug("sending request: %s" % prepped.url)
+            response = self.requests_session.send(prepped)
 
-		return response
+        return response
 
-	def get(self, resource, filter_string=None, select=None):
-		params = {
-			"$top": 2,
-			"$select": select or "*",
-			"$filter": filter_string,
-			"$inlinecount": "allpages"  # this forces a returned dict (otherwise we might get a list with one entry)
-		}
-		r = self._send("GET", resource, params=params)
+    def get(self, resource, filter_string=None, select=None):
+        params = {
+            "$top": 2,
+            "$select": select or "*",
+            "$filter": filter_string,
+            "$inlinecount": "allpages"  # this forces a returned dict (otherwise we might get a list with one entry)
+        }
+        r = self._send("GET", resource, params=params)
 
-		data = r["d"]["results"]
-		if len(data) == 0:
-			raise DoesNotExist("recource not found. params were: %r" % params)
-		if len(data) > 1:
-			raise MultipleObjectsReturned("api returned multiple objects. params were: %r" % params)
-		return data[0]
+        data = r["d"]["results"]
+        if len(data) == 0:
+            raise DoesNotExist("recource not found. params were: %r" % params)
+        if len(data) > 1:
+            raise MultipleObjectsReturned("api returned multiple objects. params were: %r" % params)
+        return data[0]
 
-	def filter(self, resource, filter_string=None, select=None, order_by=None, limit=None, expand=None):
-		params = {
-			"$filter": filter_string,
-			"$expand": expand,
-			"$select": select,
-			"$orderby": order_by,
-			"$top": limit,
-			"$inlinecount": "allpages"
-		}
-		response = self._send("GET", resource, params=params)
-		results = response["d"]["results"]
-		for r in results:
-			yield r
+    def filter(self, resource, filter_string=None, select=None, order_by=None, limit=None, expand=None):
+        params = {
+            "$filter": filter_string,
+            "$expand": expand,
+            "$select": select,
+            "$orderby": order_by,
+            "$top": limit,
+            "$inlinecount": "allpages"
+        }
+        response = self._send("GET", resource, params=params)
+        results = response["d"]["results"]
+        for r in results:
+            yield r
 
-		next_url = response["d"].get("__next")
-		while next_url:
-			request = Request("GET", next_url)
-			prepped = self.requests_session.prepare_request(request)
-			logger.debug("sending request: %s" % prepped.url)
-			response = self.requests_session.send(prepped).json()
-			next_url = response["d"].get("__next")
-			results = response["d"]["results"]
-			for r in results:
-				yield r
+        next_url = response["d"].get("__next")
+        while next_url:
+            request = Request("GET", next_url)
+            prepped = self.requests_session.prepare_request(request)
+            logger.debug("sending request: %s" % prepped.url)
+            response = self.requests_session.send(prepped).json()
+            next_url = response["d"].get("__next")
+            results = response["d"]["results"]
+            for r in results:
+                yield r
 
-	def create(self, resource, data):
-		# TODO: add possibility to use a more advanced json encoder
-		r = self._send("POST", resource, data=json.dumps(data))
-		return r["d"]
+    def create(self, resource, data):
+        # TODO: add possibility to use a more advanced json encoder
+        r = self._send("POST", resource, data=json.dumps(data))
+        return r["d"]
 
-	def update(self, resource, guid, data):
-		# TODO: add possibility to use a more advanced json encoder
-		resource = "%s(guid'%s')" % (resource, guid)
-		r = self._send("PUT", resource, data=json.dumps(data))
-		return r
+    def update(self, resource, guid, data):
+        # TODO: add possibility to use a more advanced json encoder
+        resource = "%s(guid'%s')" % (resource, guid)
+        r = self._send("PUT", resource, data=json.dumps(data))
+        return r
 
-	def delete(self, resource, guid):
-		resource = "%s(guid'%s')" % (resource, guid)
-		r = self._send("DELETE", resource)
-		return r
+    def delete(self, resource, guid):
+        resource = "%s(guid'%s')" % (resource, guid)
+        r = self._send("DELETE", resource)
+        return r

--- a/exact/app.py
+++ b/exact/app.py
@@ -3,8 +3,8 @@ from django.utils.translation import ugettext_lazy
 
 
 class Config(AppConfig):
-	name = "exact"
-	verbose_name = ugettext_lazy(u"Exact Online")
+    name = "exact"
+    verbose_name = ugettext_lazy(u"Exact Online")
 
-	def ready(self):
-		import exact.signals
+    def ready(self):
+        import exact.signals

--- a/exact/models.py
+++ b/exact/models.py
@@ -8,43 +8,43 @@ from django.utils.translation import ugettext_lazy as _
 
 
 class Session(models.Model):
-	api_url = models.URLField(_("API base URL"), help_text=_("E.g https://start.exactonline.nl/api"))
-	client_id = models.CharField(max_length=255, help_text=_("Your OAuth2/Exact App client ID"))
-	client_secret = models.CharField(max_length=255, help_text=_("Your OAuth2/Exact App client secret"))
-	redirect_uri = models.URLField(_("OAuth2 redirect URI"), help_text=_("Callback URL on your server. https://example.com/exact/authenticate"))
-	division = models.IntegerField()
+    api_url = models.URLField(_("API base URL"), help_text=_("E.g https://start.exactonline.nl/api"))
+    client_id = models.CharField(max_length=255, help_text=_("Your OAuth2/Exact App client ID"))
+    client_secret = models.CharField(max_length=255, help_text=_("Your OAuth2/Exact App client secret"))
+    redirect_uri = models.URLField(_("OAuth2 redirect URI"), help_text=_("Callback URL on your server. https://example.com/exact/authenticate"))
+    division = models.IntegerField()
 
-	access_expiry = models.IntegerField(blank=True, null=True)
-	access_token = models.TextField(blank=True, null=True)
-	refresh_token = models.TextField(blank=True, null=True)
-	authorization_code = models.TextField(blank=True, null=True)
+    access_expiry = models.IntegerField(blank=True, null=True)
+    access_token = models.TextField(blank=True, null=True)
+    refresh_token = models.TextField(blank=True, null=True)
+    authorization_code = models.TextField(blank=True, null=True)
 
 
 def _default_callback_url():
-	return "https://%s%s" % (Site.objects.get_current().domain, reverse("exact:webhook"))
+    return "https://%s%s" % (Site.objects.get_current().domain, reverse("exact:webhook"))
 
 
 class Webhook(models.Model):
-	TOPIC_CHOICES = (
-		("Accounts", _("Accounts")),
-		("BankAccounts", _("Bank Accounts")),
-		("Contacts", _("Contacts")),
-		("CostTransactions", _("CostTransactions")),
-		("DocumentAttachments", _("Document Attachments")),
-		("Documents", _("Documents")),
-		("FinancialTransactions", _("FinancialTransactions")),
-		("GoodsDeliveries", _("GoodsDeliveries")),
-		("Items", _("Items")),
-		("ProjectPlanning", _("ProjectPlanning")),
-		("PurchaseOrders", _("PurchaseOrders")),
-		("Quotations", _("Quotations")),
-		("SalesInvoices", _("SalesInvoices")),
-		("SalesOrders", _("SalesOrders")),
-		("StockPositions", _("StockPositions")),
-		("TimeTransactions", _("TimeTransactions")),
-	)
-	topic = models.CharField(choices=TOPIC_CHOICES, max_length=255, unique=True)
-	callback = models.URLField(_("Callback"), help_text=_("Webhook callback"), default=_default_callback_url)
+    TOPIC_CHOICES = (
+        ("Accounts", _("Accounts")),
+        ("BankAccounts", _("Bank Accounts")),
+        ("Contacts", _("Contacts")),
+        ("CostTransactions", _("CostTransactions")),
+        ("DocumentAttachments", _("Document Attachments")),
+        ("Documents", _("Documents")),
+        ("FinancialTransactions", _("FinancialTransactions")),
+        ("GoodsDeliveries", _("GoodsDeliveries")),
+        ("Items", _("Items")),
+        ("ProjectPlanning", _("ProjectPlanning")),
+        ("PurchaseOrders", _("PurchaseOrders")),
+        ("Quotations", _("Quotations")),
+        ("SalesInvoices", _("SalesInvoices")),
+        ("SalesOrders", _("SalesOrders")),
+        ("StockPositions", _("StockPositions")),
+        ("TimeTransactions", _("TimeTransactions")),
+    )
+    topic = models.CharField(choices=TOPIC_CHOICES, max_length=255, unique=True)
+    callback = models.URLField(_("Callback"), help_text=_("Webhook callback"), default=_default_callback_url)
 
-	# division = models.PositiveIntegerField(_("Division"), help_text=_("Company inside Exact Online."))
-	guid = models.CharField(max_length=36, blank=True, null=True)
+    # division = models.PositiveIntegerField(_("Division"), help_text=_("Company inside Exact Online."))
+    guid = models.CharField(max_length=36, blank=True, null=True)

--- a/exact/signals.py
+++ b/exact/signals.py
@@ -15,26 +15,26 @@ logger = logging.getLogger("exact")
 
 @receiver(post_delete, sender=Webhook)
 def delete_webhook(sender, instance, *args, **kwargs):
-	if instance.guid:
-		api = Exact()
-		logger.debug("deleting webhook %s: %s -> %s" % (instance.guid, instance.topic, instance.callback))
-		api.delete("webhooks/WebhookSubscriptions", instance.guid)
+    if instance.guid:
+        api = Exact()
+        logger.debug("deleting webhook %s: %s -> %s" % (instance.guid, instance.topic, instance.callback))
+        api.delete("webhooks/WebhookSubscriptions", instance.guid)
 
 
 @receiver(pre_save, sender=Webhook)
 def create_or_update_webhook(sender, instance, raw, *args, **kwargs):
-	if not raw:
-		api = Exact()
-		if instance.pk or instance.guid:
-			logger.debug("updating webhook %s: %s -> %s" % (instance.guid, instance.topic, instance.callback))
-			api.update("webhooks/WebhookSubscriptions", instance.guid, {
-				"Topic": instance.topic,
-				"CallbackURL": instance.callback
-			})
-		else:
-			logger.debug("creating webhook: %s -> %s" % (instance.topic, instance.callback))
-			webhook = api.create("webhooks/WebhookSubscriptions", {
-				"Topic": instance.topic,
-				"CallbackURL": instance.callback
-			})
-			instance.guid = webhook["ID"]
+    if not raw:
+        api = Exact()
+        if instance.pk or instance.guid:
+            logger.debug("updating webhook %s: %s -> %s" % (instance.guid, instance.topic, instance.callback))
+            api.update("webhooks/WebhookSubscriptions", instance.guid, {
+                "Topic": instance.topic,
+                "CallbackURL": instance.callback
+            })
+        else:
+            logger.debug("creating webhook: %s -> %s" % (instance.topic, instance.callback))
+            webhook = api.create("webhooks/WebhookSubscriptions", {
+                "Topic": instance.topic,
+                "CallbackURL": instance.callback
+            })
+            instance.guid = webhook["ID"]

--- a/exact/storage.py
+++ b/exact/storage.py
@@ -9,59 +9,59 @@ from exact.models import Session
 
 
 class DjangoStorage(ExactOnlineConfig):
-	def __init__(self):
-		s, created = Session.objects.get_or_create(**EXACT_SETTINGS)
-		self._session = s
+    def __init__(self):
+        s, created = Session.objects.get_or_create(**EXACT_SETTINGS)
+        self._session = s
 
-	def get_auth_url(self):
-		return self._session.api_url + "/oauth2/auth"
+    def get_auth_url(self):
+        return self._session.api_url + "/oauth2/auth"
 
-	def get_rest_url(self):
-		return self._session.api_url
+    def get_rest_url(self):
+        return self._session.api_url
 
-	def get_token_url(self):
-		return self._session.api_url + "/oauth2/token"
+    def get_token_url(self):
+        return self._session.api_url + "/oauth2/token"
 
-	def get_base_url(self):
-		return self._session.redirect_uri
+    def get_base_url(self):
+        return self._session.redirect_uri
 
-	def get_client_id(self):
-		return self._session.client_id
+    def get_client_id(self):
+        return self._session.client_id
 
-	def get_client_secret(self):
-		return self._session.client_secret
+    def get_client_secret(self):
+        return self._session.client_secret
 
-	def get_access_expiry(self):
-		return self._session.access_expiry
+    def get_access_expiry(self):
+        return self._session.access_expiry
 
-	def set_access_expiry(self, value):
-		self._session.access_expiry = value
-		self._session.save()
+    def set_access_expiry(self, value):
+        self._session.access_expiry = value
+        self._session.save()
 
-	def get_access_token(self):
-		return self._session.access_token
+    def get_access_token(self):
+        return self._session.access_token
 
-	def set_access_token(self, value):
-		self._session.access_token = value
-		self._session.save()
+    def set_access_token(self, value):
+        self._session.access_token = value
+        self._session.save()
 
-	def get_code(self):
-		return self._session.authorization_code
+    def get_code(self):
+        return self._session.authorization_code
 
-	def set_code(self, value):
-		self._session.authorization_code = value
-		self._session.save()
+    def set_code(self, value):
+        self._session.authorization_code = value
+        self._session.save()
 
-	def get_division(self):
-		return self._session.division
+    def get_division(self):
+        return self._session.division
 
-	def set_division(self, value):
-		self._session.division = value
-		self._session.save()
+    def set_division(self, value):
+        self._session.division = value
+        self._session.save()
 
-	def get_refresh_token(self):
-		return self._session.refresh_token
+    def get_refresh_token(self):
+        return self._session.refresh_token
 
-	def set_refresh_token(self, value):
-		self._session.refresh_token = value
-		self._session.save()
+    def set_refresh_token(self, value):
+        self._session.refresh_token = value
+        self._session.save()

--- a/exact/urls.py
+++ b/exact/urls.py
@@ -5,7 +5,7 @@ from django.conf.urls import url
 from .views import Authenticate, Status, webhook
 
 urlpatterns = [
-	url(r'^authenticate$', Authenticate.as_view(), name="authenticate"),
-	url(r'^status', Status.as_view(), name="status"),
-	url(r'^webhook', webhook, name="webhook"),
+    url(r'^authenticate$', Authenticate.as_view(), name="authenticate"),
+    url(r'^status', Status.as_view(), name="status"),
+    url(r'^webhook', webhook, name="webhook"),
 ]

--- a/exact/views.py
+++ b/exact/views.py
@@ -20,66 +20,66 @@ from exact.api import Exact
 
 @method_decorator(user_passes_test(lambda u: u.is_staff), name="dispatch")
 class Authenticate(RedirectView):
-	pattern_name = "exact:status"
+    pattern_name = "exact:status"
 
-	def get_redirect_url(self, *args, **kwargs):
-		api = Exact()
-		if self.request.GET.get("code"):
-			api.session.authorization_code = self.request.GET.get("code")
-			api.session.save()
+    def get_redirect_url(self, *args, **kwargs):
+        api = Exact()
+        if self.request.GET.get("code"):
+            api.session.authorization_code = self.request.GET.get("code")
+            api.session.save()
 
-		if not api.session.authorization_code:
-			return api.auth_url
+        if not api.session.authorization_code:
+            return api.auth_url
 
-		if not api.session.access_token:
-			api.get_token()
+        if not api.session.access_token:
+            api.get_token()
 
-		return super(Authenticate, self).get_redirect_url(*args, **kwargs)
+        return super(Authenticate, self).get_redirect_url(*args, **kwargs)
 
 
 @method_decorator(user_passes_test(lambda u: u.is_staff), name="dispatch")
 class Status(TemplateView):
-	template_name = "exact/status.html"
-	api = None
+    template_name = "exact/status.html"
+    api = None
 
-	def dispatch(self, request, *args, **kwargs):
-		api = Exact()
-		if not api.session.authorization_code or not api.session.access_token:
-			return HttpResponseRedirect(reverse("exact:authenticate"))
-		self.api = api
-		return super(Status, self).dispatch(request, *args, **kwargs)
+    def dispatch(self, request, *args, **kwargs):
+        api = Exact()
+        if not api.session.authorization_code or not api.session.access_token:
+            return HttpResponseRedirect(reverse("exact:authenticate"))
+        self.api = api
+        return super(Status, self).dispatch(request, *args, **kwargs)
 
-	def get_context_data(self, **kwargs):
-		ctx = super(Status, self).get_context_data(**kwargs)
-		start = datetime.now()
-		# eval generator to force a possible re-auth
-		ctx["webhooks"] = list(self.api.filter("webhooks/WebhookSubscriptions"))
+    def get_context_data(self, **kwargs):
+        ctx = super(Status, self).get_context_data(**kwargs)
+        start = datetime.now()
+        # eval generator to force a possible re-auth
+        ctx["webhooks"] = list(self.api.filter("webhooks/WebhookSubscriptions"))
 
-		response = self.api.raw("GET", "/v1/current/Me", params={"$select": "FullName,Email,ThumbnailPicture"})
-		ctx["api_user"] = response.json()["d"]["results"][0]
+        response = self.api.raw("GET", "/v1/current/Me", params={"$select": "FullName,Email,ThumbnailPicture"})
+        ctx["api_user"] = response.json()["d"]["results"][0]
 
-		ctx["division"] = self.api.get(
-			"hrm/Divisions",
-			filter_string="Code eq %d" % self.api.session.division,
-			select="Code,CustomerName,Description,Country"
-		)
-		ctx["dt"] = datetime.now() - start
-		return ctx
+        ctx["division"] = self.api.get(
+            "hrm/Divisions",
+            filter_string="Code eq %d" % self.api.session.division,
+            select="Code,CustomerName,Description,Country"
+        )
+        ctx["dt"] = datetime.now() - start
+        return ctx
 
 
 @csrf_exempt
 def webhook(request):
-	# TODO: show how to validate request
-	logger = logging.getLogger("exact")
-	if request.method != "POST":
-		return HttpResponseNotAllowed(["POST"])
-	if len(request.body) == 0:
-		return HttpResponse()
-	try:
-		data = json.loads(request.body)
-		logger.debug(data)
-		return HttpResponse(request.body)
-	except Exception as e:
-		logger.debug("error: " + request.body)
-		return HttpResponseBadRequest(e)
+    # TODO: show how to validate request
+    logger = logging.getLogger("exact")
+    if request.method != "POST":
+        return HttpResponseNotAllowed(["POST"])
+    if len(request.body) == 0:
+        return HttpResponse()
+    try:
+        data = json.loads(request.body)
+        logger.debug(data)
+        return HttpResponse(request.body)
+    except Exception as e:
+        logger.debug("error: " + request.body)
+        return HttpResponseBadRequest(e)
 

--- a/setup.py
+++ b/setup.py
@@ -2,37 +2,37 @@
 from setuptools import setup, find_packages
 
 setup(
-	name='django-exact',
+    name='django-exact',
 
-	# Versions should comply with PEP440.  For a discussion on single-sourcing
-	# the version across setup.py and the project code, see
-	# https://packaging.python.org/en/latest/single_source_version.html
-	version='0.2.5',
+    # Versions should comply with PEP440.  For a discussion on single-sourcing
+    # the version across setup.py and the project code, see
+    # https://packaging.python.org/en/latest/single_source_version.html
+    version='0.2.5',
 
-	description='API Wrapper and Django app for Exact Online',
-	# long_description='',
+    description='API Wrapper and Django app for Exact Online',
+    # long_description='',
 
-	# The project's main homepage.
-	url='https://github.com/affiliprint/django-exact',
+    # The project's main homepage.
+    url='https://github.com/affiliprint/django-exact',
 
-	# Author details
-	author='Malte Böhme, Affiliprint Deutschland GmbH',
-	author_email='malte.boehme@affiliprint.com',
+    # Author details
+    author='Malte Böhme, Affiliprint Deutschland GmbH',
+    author_email='malte.boehme@affiliprint.com',
 
-	# Choose your license
-	license='MIT',
+    # Choose your license
+    license='MIT',
 
-	# You can just specify the packages manually here if your project is
-	# simple. Or you can use find_packages().
-	packages=find_packages(),
-	include_package_data=True,
-	# Alternatively, if you want to distribute just a my_module.py, uncomment
-	# this:
-	#   py_modules=["my_module"],
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    packages=find_packages(),
+    include_package_data=True,
+    # Alternatively, if you want to distribute just a my_module.py, uncomment
+    # this:
+    #   py_modules=["my_module"],
 
-	# List run-time dependencies here.  These will be installed by pip when
-	# your project is installed. For an analysis of "install_requires" vs pip's
-	# requirements files see:
-	# https://packaging.python.org/en/latest/requirements.html
-	install_requires=['Django', 'requests'],
+    # List run-time dependencies here.  These will be installed by pip when
+    # your project is installed. For an analysis of "install_requires" vs pip's
+    # requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=['Django', 'requests'],
 )


### PR DESCRIPTION
Hi, thanks for your great work.
I took the liberty of converting your tabs to spaces in all python files, which is the standard for python:

https://www.python.org/dev/peps/pep-0008/#tabs-or-spaces

The migrations allready used spaces, now all files are the same. They also look better now in github, which displays tabs as 8 spaces instead of 4.
