### PR TITLE
Add status template thumbnail existence missed check

### DIFF
--- a/exact/templates/exact/status.html
+++ b/exact/templates/exact/status.html
@@ -11,7 +11,7 @@
 	{% for k,v in api_user.items %}
 		{% if k == "__metadata" %}
 		{% elif k == "ThumbnailPicture" %}
-			<img src="data:image/jpg;base64, {{ v }}"/>
+			{% if v %}<img src="data:image/jpg;base64, {{ v }}"/>{% endif %}
 		{% else %}
 			<li>{{ k }}: {{ v }}</li>
 		{% endif %}


### PR DESCRIPTION
This pull request adds a check for the existence of the authenticated user's thumbnail picture in a template that displays the user's status on the site. Previously, the template did not include this check, which could result in an error if the user did not have a thumbnail picture set.