### PR TITLE
Add ability to override division setting on API instantiation

### DIFF
--- a/exact/api.py
+++ b/exact/api.py
@@ -29,8 +29,7 @@ EXACT_SETTINGS = {
 	"redirect_uri": _get("REDIRECT_URI"),
 	"client_id": _get("CLIENT_ID"),
 	"client_secret": _get("CLIENT_SECRET"),
-	"api_url": _get("API_URL"),
-	"division": _get("DIVISION")
+	"api_url": _get("API_URL")
 }
 
 
@@ -148,7 +147,14 @@ class Exact(object):
 	# so reusing it speeds things up a lot. (~200ms per call)
 	_REUSE_SESSION = True
 
-	def __init__(self):
+	def __init__(self, division=None):
+		if division is None:
+			try:
+				division = _get("DIVISION")  # get from django settings
+			except ImproperlyConfigured:
+				raise ImproperlyConfigured("The division parameter must be provided or set in the settings.")
+
+		self.division = division
 		s, created = Session.objects.get_or_create(**EXACT_SETTINGS)
 		self.session = s
 
@@ -239,7 +245,7 @@ class Exact(object):
 				"Prefer": "return=representation",
 			})
 
-		url = "%s/v1/%s/%s" % (self.session.api_url, self.session.division, resource)
+		url = "%s/v1/%s/%s" % (self.session.api_url, self.division, resource)
 		request = Request(method, url, data=data, params=params)
 		prepped = self.requests_session.prepare_request(request)
 

--- a/exact/api.py
+++ b/exact/api.py
@@ -29,7 +29,8 @@ EXACT_SETTINGS = {
 	"redirect_uri": _get("REDIRECT_URI"),
 	"client_id": _get("CLIENT_ID"),
 	"client_secret": _get("CLIENT_SECRET"),
-	"api_url": _get("API_URL")
+	"api_url": _get("API_URL"),
+	"division": _get("DIVISION")
 }
 
 
@@ -149,13 +150,11 @@ class Exact(object):
 
 	def __init__(self, division=None):
 		if division is None:
-			try:
-				division = _get("DIVISION")  # get from django settings
-			except ImproperlyConfigured:
-				raise ImproperlyConfigured("The division parameter must be provided or set in the settings.")
-
+			division = EXACT_SETTINGS["division"]
 		self.division = division
-		s, created = Session.objects.get_or_create(**EXACT_SETTINGS)
+
+		session_kwargs = {k: v for k, v in EXACT_SETTINGS.items() if k != "division"}
+		s, created = Session.objects.get_or_create(**session_kwargs)
 		self.session = s
 
 		retry_strategy = Retry(

--- a/exact/migrations/0002_remove_session_division.py
+++ b/exact/migrations/0002_remove_session_division.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('exact', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='session',
+            name='division',
+        ),
+    ]

--- a/exact/models.py
+++ b/exact/models.py
@@ -10,7 +10,6 @@ class Session(models.Model):
 	client_id = models.CharField(max_length=255, help_text=_("Your OAuth2/Exact App client ID"))
 	client_secret = models.CharField(max_length=255, help_text=_("Your OAuth2/Exact App client secret"))
 	redirect_uri = models.URLField(_("OAuth2 redirect URI"), help_text=_("Callback URL on your server. https://example.com/exact/authenticate"))
-	division = models.IntegerField()
 
 	access_expiry = models.IntegerField(blank=True, null=True)
 	access_token = models.TextField(blank=True, null=True)

--- a/exact/templates/exact/status.html
+++ b/exact/templates/exact/status.html
@@ -18,16 +18,6 @@
 	{% endfor %}
 </ul>
 
-<div>Division:</div>
-<ul>
-	{% for k,v in division.items %}
-		{% if k == "__metadata" %}
-		{% else %}
-			<li>{{ k }}: {{ v }}</li>
-		{% endif %}
-	{% endfor %}
-</ul>
-
 <div>Webhooks:</div>
 {% for webhook in webhooks %}
 	<ul>

--- a/exact/views.py
+++ b/exact/views.py
@@ -56,11 +56,6 @@ class Status(TemplateView):
 		response = self.api.raw("GET", "/v1/current/Me", params={"$select": "FullName,Email,ThumbnailPicture"})
 		ctx["api_user"] = response.json()["d"]["results"][0]
 
-		ctx["division"] = self.api.get(
-			"hrm/Divisions",
-			filter_string="Code eq %d" % self.api.session.division,
-			select="Code,CustomerName,Description,Country"
-		)
 		ctx["dt"] = datetime.now() - start
 		return ctx
 


### PR DESCRIPTION
This pull request updates the Exact API to accept the division parameter on API instantiation, and to get the value of division from the settings if it is not provided. This change was made to enable making requests to multiple divisions.